### PR TITLE
Add initial local frontend

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+package-lock.json
+tsconfig.json

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,2 @@
 /node_modules
 package-lock.json
-tsconfig.json

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,7 +25,7 @@ Files removed:
 
 `App.tsx` was renamed to `LendAHand.tsx` 
 
-The folder `Public` and its contents were removed.
+Everything except `index.html` was removed from `/Public`.
 
 Packages installed
  - @materials/ui

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,6 +29,7 @@ Everything except `index.html` was removed from `/Public`.
 
 Packages installed
  - @materials/ui
+ - @mui/icons-material
  - @emotion/react
  - @emotion/styled
  - react-router-dom

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,8 +5,7 @@
 ---
 ## About
 
-Frontend uses typescript, react and MUI.  
-After pulling, cd into frontend and run `npm install`. This will ensure you have all packages needed to run frontend.  
+Frontend uses Typescript, React and MUI.   
 
 ---
 ## To Run

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,6 +9,14 @@ Frontend uses typescript, react and MUI.
 After pulling, cd into frontend and run `npm install`. This will ensure you have all packages needed to run frontend.  
 
 ---
+## To Run
+
+1 - First pull the branch to ensure you have the most recent update  
+2 - cd into frontend  
+3 - run `npm install`  
+4 - run `npm run start`  
+
+---
 
 ## Creation Info
 Frontend is a react app created using `npx  create-react-app frontend --template typescript`  

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,36 @@
+# READEME - FrontEnd
+
+#### Lead FrontEnd Developer: `Taylor Noah`
+
+---
+## About
+
+Frontend uses typescript, react and MUI.
+
+---
+
+## Creation Info
+Frontend is a react app created using `npx  create-react-app frontend --template typescript`  
+
+Then some parts of the template were removed or changed as follows:
+
+Files removed:
+ - app.css
+ - app.test.tsx
+ - index.css
+ - logo.svg
+ - react-app-env.d
+ - setupTests.ts
+
+`App.tsx` was renamed to `LendAHand.tsx` 
+
+The folder `Public` and its contents were removed.
+
+Packages installed
+ - @materials/ui
+ - @emotion/react
+ - @emotion/styled
+ - react-router-dom
+
+---
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,7 +5,8 @@
 ---
 ## About
 
-Frontend uses typescript, react and MUI.
+Frontend uses typescript, react and MUI.  
+After pulling, cd into frontend and run `npm install`. This will ensure you have all packages needed to run frontend.  
 
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/react": "^13.2.0",
+    "@testing-library/user-event": "^13.5.0",
+    "@types/jest": "^27.5.0",
+    "@types/node": "^16.11.33",
+    "@types/react": "^18.0.9",
+    "@types/react-dom": "^18.0.3",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0",
+    "react-scripts": "5.0.1",
+    "typescript": "^4.6.4",
+    "web-vitals": "^2.1.4"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emotion/react": "^11.9.0",
+    "@emotion/styled": "^11.8.1",
+    "@mui/icons-material": "^5.6.2",
+    "@mui/material": "^5.6.4",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",
@@ -12,6 +16,7 @@
     "@types/react-dom": "^18.0.3",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.6.4",
     "web-vitals": "^2.1.4"

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Web site created using create-react-app"
+    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>React App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,24 @@
 import * as React from 'react';
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import AppBar from './Components/AppBar';
-import { NotFound } from './Components/NotFound';
+import LandingPage from './Components/LandingPage';
+import NotFound from './Components/NotFound';
 
 
 
 
 function App() {
+
+	const landingPage = <LandingPage/>
+	const notFound = <NotFound/>
   return (
     <>
       <BrowserRouter>
        <Routes>
-          <Route path="/" element={<AppBar />}></Route>
-          <Route path="*" element={<NotFound />}/>
+          <Route path="/" element={<AppBar />}>
+						<Route path="/" element={landingPage}/>
+					</Route>
+          <Route path="*" element={notFound}/>
         </Routes>
       </BrowserRouter>
     </>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,21 @@
 import * as React from 'react';
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import AppBar from './Components/AppBar';
+import { NotFound } from './Components/NotFound';
 
 
-const  App = () => {
+
+
+function App() {
   return (
-   <h1>Lend A Hand !</h1>
+    <>
+      <BrowserRouter>
+       <Routes>
+          <Route path="/" element={<AppBar />}></Route>
+          <Route path="*" element={<NotFound />}/>
+        </Routes>
+      </BrowserRouter>
+    </>
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import './App.css';
+
+function App() {
+  return (
+   <h1>Lend A Hand !</h1>
+  );
+}
+
+export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import './App.css';
 
-function App() {
+
+const  App = () => {
   return (
    <h1>Lend A Hand !</h1>
   );

--- a/frontend/src/Components/AppBar.tsx
+++ b/frontend/src/Components/AppBar.tsx
@@ -1,10 +1,18 @@
+import { Outlet } from "react-router-dom";
 import {Box, AppBar as Bar, Toolbar, Typography, Button, ButtonGroup} from '@mui/material'
 import { APPBAR } from '../Constants';
 
 const AppBar = () => {
 
-	const buttonSX = {
-		mr: 1, 
+	const middleButtonSX = {
+		mr: 1,
+		ml: 10, 
+		textTransform: 'none',
+		borderRadius: 28
+	}
+
+	const rightButtonsSX = {
+		mr: 1,
 		textTransform: 'none',
 		borderRadius: 28
 	}
@@ -14,19 +22,21 @@ const AppBar = () => {
 			<Bar>
 				<Toolbar>
 					<Box display='flex' width={1} justifyContent='left'>
-						<Typography variant='h4'>
-							{APPBAR.TITLE}
-						</Typography>
+						<Button>
+							<Typography variant='h4' color='white' sx={{textTransform: 'none'}}>
+								{APPBAR.TITLE}
+							</Typography>
+						</Button>
 					</Box>
 
 					<Box width={1} display='flex' justifyContent='center'>
 						<ButtonGroup size='medium'  color='success' >
-							<Button sx={buttonSX} variant='contained'>
+							<Button sx={middleButtonSX} variant='contained'>
 								<Typography variant="h5">
 									{APPBAR.LEND}
 								</Typography>
 							</Button>
-							<Button sx={buttonSX} variant='contained'>
+							<Button sx={middleButtonSX} variant='contained'>
 								<Typography variant="h5">
 									{APPBAR.REQUEST}
 								</Typography>
@@ -36,12 +46,12 @@ const AppBar = () => {
 					</Box>
 
 					<Box width={1} display='flex' justifyContent='right'>
-						<Button sx={buttonSX} size='medium' variant='contained' color='info'>
+						<Button sx={rightButtonsSX} size='medium' variant='contained' color='info'>
 							<Typography variant="subtitle1" color='white'>
 								{APPBAR.PROFILE}
 							</Typography>
 						</Button>
-						<Button sx={buttonSX} size='medium' variant='contained' color='info'>
+						<Button sx={rightButtonsSX} size='medium' variant='contained' color='info'>
 							<Typography variant="subtitle1" color='white'>
 								{APPBAR.LOGIN}
 							</Typography>
@@ -50,7 +60,11 @@ const AppBar = () => {
 
 				</Toolbar>
 			</Bar>
+
+			<Outlet />
 		</Box>
+
+		
 	
 	);
 }

--- a/frontend/src/Components/AppBar.tsx
+++ b/frontend/src/Components/AppBar.tsx
@@ -22,7 +22,7 @@ const AppBar = () => {
 			<Bar>
 				<Toolbar>
 					<Box display='flex' width={1} justifyContent='left'>
-						<Button>
+						<Button href='/'>
 							<Typography variant='h4' color='white' sx={{textTransform: 'none'}}>
 								{APPBAR.TITLE}
 							</Typography>

--- a/frontend/src/Components/AppBar.tsx
+++ b/frontend/src/Components/AppBar.tsx
@@ -1,34 +1,59 @@
-import {Box, AppBar as Bar, Toolbar, IconButton, Typography} from '@mui/material'
-import MenuIcon from '@mui/icons-material/Menu';
+import {Box, AppBar as Bar, Toolbar, Typography, Button, ButtonGroup} from '@mui/material'
 import { APPBAR } from '../Constants';
 
 const AppBar = () => {
-	return(
+
+	const buttonSX = {
+		mr: 1, 
+		textTransform: 'none',
+		borderRadius: 28
+	}
+
+	return (
 		<Box>
 			<Bar>
 				<Toolbar>
-					<Box width={0.1}>
-						<IconButton
-						size="large"
-						edge="start"
-						color="inherit"
-						aria-label="menu"
-						sx={{ mr: 2 }}
-						>
-							<MenuIcon />
-						</IconButton>
-					</Box>
-
-					<Box display='flex' width={1} justifyContent='center'>
+					<Box display='flex' width={1} justifyContent='left'>
 						<Typography variant='h4'>
 							{APPBAR.TITLE}
 						</Typography>
 					</Box>
+
+					<Box width={1} display='flex' justifyContent='center'>
+						<ButtonGroup size='medium'  color='success' >
+							<Button sx={buttonSX} variant='contained'>
+								<Typography variant="h5">
+									{APPBAR.LEND}
+								</Typography>
+							</Button>
+							<Button sx={buttonSX} variant='contained'>
+								<Typography variant="h5">
+									{APPBAR.REQUEST}
+								</Typography>
+							</Button>
+						</ButtonGroup>
+						
+					</Box>
+
+					<Box width={1} display='flex' justifyContent='right'>
+						<Button sx={buttonSX} size='medium' variant='contained' color='info'>
+							<Typography variant="subtitle1" color='white'>
+								{APPBAR.PROFILE}
+							</Typography>
+						</Button>
+						<Button sx={buttonSX} size='medium' variant='contained' color='info'>
+							<Typography variant="subtitle1" color='white'>
+								{APPBAR.LOGIN}
+							</Typography>
+						</Button>
+					</Box>
+
 				</Toolbar>
 			</Bar>
 		</Box>
 	
 	);
 }
+
 
 export default AppBar;

--- a/frontend/src/Components/AppBar.tsx
+++ b/frontend/src/Components/AppBar.tsx
@@ -1,0 +1,34 @@
+import {Box, AppBar as Bar, Toolbar, IconButton, Typography} from '@mui/material'
+import MenuIcon from '@mui/icons-material/Menu';
+import { APPBAR } from '../Constants';
+
+const AppBar = () => {
+	return(
+		<Box>
+			<Bar>
+				<Toolbar>
+					<Box width={0.1}>
+						<IconButton
+						size="large"
+						edge="start"
+						color="inherit"
+						aria-label="menu"
+						sx={{ mr: 2 }}
+						>
+							<MenuIcon />
+						</IconButton>
+					</Box>
+
+					<Box display='flex' width={1} justifyContent='center'>
+						<Typography variant='h4'>
+							{APPBAR.TITLE}
+						</Typography>
+					</Box>
+				</Toolbar>
+			</Bar>
+		</Box>
+	
+	);
+}
+
+export default AppBar;

--- a/frontend/src/Components/LandingPage.tsx
+++ b/frontend/src/Components/LandingPage.tsx
@@ -14,7 +14,7 @@ const LandingPage = () => {
 				<img  
 					alt='Sharing' 
 					src={LANDING.imgsrc}
-					width={1400}
+					width={1200}
 				/>
 			</Box>
 		</>

--- a/frontend/src/Components/LandingPage.tsx
+++ b/frontend/src/Components/LandingPage.tsx
@@ -1,15 +1,24 @@
 import { Box } from "@mui/material";
 import { LANDING } from "../Constants";
+import { Typography } from "@mui/material";
 
 const LandingPage = () => {
 	return (
-		<Box width={1} display='flex' justifyContent='center'>
-			<img  
-				alt='Sharing' 
-				src={LANDING.imgsrc}
-				width={1400}
-			/>
-		</Box>
+		<>
+			<Box  mt={15} height={1} display='flex' justifyContent='center'>
+				<Typography variant='h5'>
+					{LANDING.WELCOME}
+				</Typography>
+			</Box>
+			<Box width={1} display='flex' justifyContent='center'>
+				<img  
+					alt='Sharing' 
+					src={LANDING.imgsrc}
+					width={1400}
+				/>
+			</Box>
+		</>
+		
 	);
 }
 

--- a/frontend/src/Components/LandingPage.tsx
+++ b/frontend/src/Components/LandingPage.tsx
@@ -1,0 +1,16 @@
+import { Box } from "@mui/material";
+import { LANDING } from "../Constants";
+
+const LandingPage = () => {
+	return (
+		<Box width={1} display='flex' justifyContent='center'>
+			<img  
+				alt='Sharing' 
+				src={LANDING.imgsrc}
+				width={1400}
+			/>
+		</Box>
+	);
+}
+
+export default LandingPage;

--- a/frontend/src/Components/NotFound.tsx
+++ b/frontend/src/Components/NotFound.tsx
@@ -1,4 +1,3 @@
-import {Link} from "@mui/material";
 import {Box, Typography, Button} from '@mui/material'
 
 

--- a/frontend/src/Components/NotFound.tsx
+++ b/frontend/src/Components/NotFound.tsx
@@ -1,18 +1,19 @@
 import {Box, Typography, Button} from '@mui/material'
+import { E404 } from '../Constants';
 
 
-export const NotFound = () => (
+const NotFound = () => (
 	<Box>
-	  <Typography variant='h1'>404 - Not Found!</Typography>
+	  <Typography variant='h1'>{E404.TITLE}</Typography>
 	  <Box display='flex' mt={10}>
-		<Typography>Looks Like something went wrong. Better </Typography>
-		<Box mt={-1} ml={1}>
-			<Button sx={{textTransform: 'none'}} variant='contained' href='/'>
-				<Typography variant="body1">
-					Go Home
-				</Typography>
-			</Button>
-		</Box>
+			<Typography>{E404.MESSAGE}</Typography>
+			<Box mt={-1} ml={1}>
+				<Button sx={{textTransform: 'none'}} variant='contained' href='/'>
+					<Typography variant="body1">{E404.BUTTON}</Typography>
+				</Button>
+			</Box>
 	  </Box>
 	</Box>
 );
+
+export default NotFound;

--- a/frontend/src/Components/NotFound.tsx
+++ b/frontend/src/Components/NotFound.tsx
@@ -1,0 +1,19 @@
+import {Link} from "@mui/material";
+import {Box, Typography, Button} from '@mui/material'
+
+
+export const NotFound = () => (
+	<Box>
+	  <Typography variant='h1'>404 - Not Found!</Typography>
+	  <Box display='flex' mt={10}>
+		<Typography>Looks Like something went wrong. Better </Typography>
+		<Box mt={-1} ml={1}>
+			<Button sx={{textTransform: 'none'}} variant='contained' href='/'>
+				<Typography variant="body1">
+					Go Home
+				</Typography>
+			</Button>
+		</Box>
+	  </Box>
+	</Box>
+);

--- a/frontend/src/Constants.ts
+++ b/frontend/src/Constants.ts
@@ -1,7 +1,18 @@
+export const E404 = {
+	TITLE: '404 - Not Found!',
+	MESSAGE: 'Looks Like something went wrong. Better ',
+	BUTTON: 'Go Home'
+}
+
 export const APPBAR = {
 	TITLE:  'Lend a hand',
 	LEND: 'Lend',
 	REQUEST: 'Request',
 	PROFILE: 'Profile',
 	LOGIN: 'Login'
+}
+
+
+export const LANDING = {
+	imgsrc: 'https://thumbs.dreamstime.com/b/siblings-relationship-kids-sharing-delicious-fruit-together-sister-brother-holding-apple-siblings-relationship-kids-sharing-145343792.jpg'
 }

--- a/frontend/src/Constants.ts
+++ b/frontend/src/Constants.ts
@@ -1,0 +1,3 @@
+export const APPBAR = {
+	TITLE:  'Lend A Hand !'
+}

--- a/frontend/src/Constants.ts
+++ b/frontend/src/Constants.ts
@@ -1,3 +1,7 @@
 export const APPBAR = {
-	TITLE:  'Lend A Hand !'
+	TITLE:  'Lend a hand',
+	LEND: 'Lend',
+	REQUEST: 'Request',
+	PROFILE: 'Profile',
+	LOGIN: 'Login'
 }

--- a/frontend/src/Constants.ts
+++ b/frontend/src/Constants.ts
@@ -14,5 +14,6 @@ export const APPBAR = {
 
 
 export const LANDING = {
+	WELCOME: '	Welcome to Lend a hand! Click one of the above buttons to get started!',
 	imgsrc: 'https://thumbs.dreamstime.com/b/siblings-relationship-kids-sharing-delicious-fruit-together-sister-brother-holding-apple-siblings-relationship-kids-sharing-145343792.jpg'
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
I created an initial local frontend server. It has a landing page that consists of an appbar and a cool menu icon that can be clicked but does nothing, and a 404 not found page for non-existent paths.

To run it, after you pull, cd into frontend, run `npm install` then `npm run start`. Check it out in your browser at localhost:3000.